### PR TITLE
Check the gas limit on incoming transactions

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -189,7 +189,7 @@ func Start() error {
 		BackendURL:        backendURL,
 		HTTPListenAddress: Config.HTTPListenAddress,
 		DelayInSeconds:    Config.DelayInSeconds,
-		ChainGasLimit:     uint64(Config.ChainGasLimit),
+		ChainGasLimit:     Config.ChainGasLimit,
 	}
 
 	service := server.NewRPCService(processor, config)

--- a/src/main.go
+++ b/src/main.go
@@ -34,6 +34,7 @@ var Config struct {
 	SequencerAddress            string `mapstructure:"sequencer-address"`
 	KeyperSetManagerAddress     string `mapstructure:"keyperset-manager-address"`
 	DelayInSeconds              int    `mapstructure:"delay-in-seconds"`
+	ChainGasLimit               uint64 `mapstructure:"chain-gas-limit"`
 }
 
 func Cmd() *cobra.Command {
@@ -106,7 +107,15 @@ func Cmd() *cobra.Command {
 		"delay-in-seconds",
 		"",
 		10,
-		"Server cache delay in seconds",
+		"server cache delay in seconds",
+	)
+
+	cmd.PersistentFlags().Uint64VarP(
+		&Config.ChainGasLimit,
+		"chain-gas-limit",
+		"",
+		1000000,
+		"chain Gas Limit",
 	)
 
 	return cmd
@@ -180,6 +189,7 @@ func Start() error {
 		BackendURL:        backendURL,
 		HTTPListenAddress: Config.HTTPListenAddress,
 		DelayInSeconds:    Config.DelayInSeconds,
+		ChainGasLimit:     uint64(Config.ChainGasLimit),
 	}
 
 	service := server.NewRPCService(processor, config)

--- a/src/main.go
+++ b/src/main.go
@@ -34,7 +34,7 @@ var Config struct {
 	SequencerAddress            string `mapstructure:"sequencer-address"`
 	KeyperSetManagerAddress     string `mapstructure:"keyperset-manager-address"`
 	DelayInSeconds              int    `mapstructure:"delay-in-seconds"`
-	ChainGasLimit               uint64 `mapstructure:"chain-gas-limit"`
+	EncryptedGasLimit           uint64 `mapstructure:"encrypted-gas-limit"`
 }
 
 func Cmd() *cobra.Command {
@@ -111,11 +111,11 @@ func Cmd() *cobra.Command {
 	)
 
 	cmd.PersistentFlags().Uint64VarP(
-		&Config.ChainGasLimit,
-		"chain-gas-limit",
+		&Config.EncryptedGasLimit,
+		"encrypted-gas-limit",
 		"",
 		1000000,
-		"chain Gas Limit",
+		"encrypted gas limit",
 	)
 
 	return cmd
@@ -189,7 +189,7 @@ func Start() error {
 		BackendURL:        backendURL,
 		HTTPListenAddress: Config.HTTPListenAddress,
 		DelayInSeconds:    Config.DelayInSeconds,
-		ChainGasLimit:     Config.ChainGasLimit,
+		EncryptedGasLimit: Config.EncryptedGasLimit,
 	}
 
 	service := server.NewRPCService(processor, config)

--- a/src/rpc/service.go
+++ b/src/rpc/service.go
@@ -27,6 +27,7 @@ type Config struct {
 	BackendURL        *url.URL
 	HTTPListenAddress string
 	DelayInSeconds    int
+	ChainGasLimit     uint64
 }
 
 type RPCService interface {

--- a/src/rpc/service.go
+++ b/src/rpc/service.go
@@ -27,7 +27,7 @@ type Config struct {
 	BackendURL        *url.URL
 	HTTPListenAddress string
 	DelayInSeconds    int
-	ChainGasLimit     uint64
+	EncryptedGasLimit uint64
 }
 
 type RPCService interface {

--- a/src/rpc/service_eth.go
+++ b/src/rpc/service_eth.go
@@ -156,7 +156,8 @@ func (service *EthService) SendRawTransaction(ctx context.Context, s string) (*c
 	}
 
 	if tx.Gas() > service.Config.EncryptedGasLimit {
-		return nil, &EncodingError{StatusCode: -32000, Err: errors.New("gas limit is higher than encrypted gas limit")}
+		return nil, &EncodingError{StatusCode: -32000, Err: errors.New("gas limit exceeds encrypted gas limit " +
+			"(max gas limit allowed per shutterized block)")}
 	}
 
 	if utils.IsCancellationTransaction(tx, fromAddress) {

--- a/src/rpc/service_eth.go
+++ b/src/rpc/service_eth.go
@@ -155,8 +155,8 @@ func (service *EthService) SendRawTransaction(ctx context.Context, s string) (*c
 		return nil, &EncodingError{StatusCode: -32000, Err: errors.New("gas cost is higher")}
 	}
 
-	if tx.Gas() > service.Config.ChainGasLimit {
-		return nil, &EncodingError{StatusCode: -32000, Err: errors.New("gas limit is higher than allowed chain limit")}
+	if tx.Gas() > service.Config.EncryptedGasLimit {
+		return nil, &EncodingError{StatusCode: -32000, Err: errors.New("gas limit is higher than encrypted gas limit")}
 	}
 
 	if utils.IsCancellationTransaction(tx, fromAddress) {

--- a/src/rpc/service_eth.go
+++ b/src/rpc/service_eth.go
@@ -155,6 +155,10 @@ func (service *EthService) SendRawTransaction(ctx context.Context, s string) (*c
 		return nil, &EncodingError{StatusCode: -32000, Err: errors.New("gas cost is higher")}
 	}
 
+	if tx.Gas() > service.Config.ChainGasLimit {
+		return nil, &EncodingError{StatusCode: -32000, Err: errors.New("gas limit is higher than allowed chain limit")}
+	}
+
 	if utils.IsCancellationTransaction(tx, fromAddress) {
 		utils.Logger.Info().Msg("Detected cancellation transaction, forwarding to backend")
 

--- a/src/rpc/service_eth_mocks_test.go
+++ b/src/rpc/service_eth_mocks_test.go
@@ -32,7 +32,7 @@ func MockConfig() rpc.Config {
 		BackendURL:        &url.URL{},
 		HTTPListenAddress: ":8546",
 		DelayInSeconds:    10,
-		ChainGasLimit:     100000,
+		EncryptedGasLimit: 100000,
 	}
 }
 

--- a/src/rpc/service_eth_mocks_test.go
+++ b/src/rpc/service_eth_mocks_test.go
@@ -32,6 +32,7 @@ func MockConfig() rpc.Config {
 		BackendURL:        &url.URL{},
 		HTTPListenAddress: ":8546",
 		DelayInSeconds:    10,
+		ChainGasLimit:     100000,
 	}
 }
 

--- a/src/rpc/service_eth_test.go
+++ b/src/rpc/service_eth_test.go
@@ -121,7 +121,7 @@ func TestSendRawTransaction_TransactionInvalid_GasCost_Higher(t *testing.T) {
 	service := initTest(t)
 
 	highCost := new(big.Int).Mul(big.NewInt(10), big.NewInt(1e18))
-	rawTx, _, err := testdata.TxWithGas(service.Processor.SigningKey, 1, big.NewInt(1), highCost)
+	rawTx, _, err := testdata.TxWithGasPrice(service.Processor.SigningKey, 1, big.NewInt(1), highCost)
 	assert.NoError(t, err, "Failed to create signed transaction")
 
 	_, err = service.SendRawTransaction(context.Background(), rawTx)
@@ -175,7 +175,7 @@ func TestSendRawTransaction_SameNonce_HigherGasPrice_Delayed(t *testing.T) {
 
 	// Send the second transaction
 	twiceGasPrice := new(big.Int).Mul(signedTx1.GasPrice(), big.NewInt(2))
-	rawTx2, signedTx2, _ := testdata.TxWithGas(service.Processor.SigningKey, nonce, chainID, twiceGasPrice)
+	rawTx2, signedTx2, _ := testdata.TxWithGasPrice(service.Processor.SigningKey, nonce, chainID, twiceGasPrice)
 
 	_, err = service.SendRawTransaction(context.Background(), rawTx2)
 	assert.NoError(t, err, "Expected transaction sending to succeed")
@@ -259,4 +259,24 @@ func TestNewTimeEvent_DeleteTxInfo(t *testing.T) {
 	_, exists := service.Cache.Data[key]
 
 	assert.False(t, exists, "Expected transaction information to be deleted from the cache")
+}
+
+func TestSendRawTransaction_GasLimitExceedsChainLimit_Error(t *testing.T) {
+	service := initTest(t)
+	highGasLimit := service.Config.ChainGasLimit + 1
+	nonce := uint64(1)
+	chainID := big.NewInt(1)
+
+	rawTx, _, err := testdata.TxWithGas(service.Processor.SigningKey, nonce, chainID, big.NewInt(2000000000), highGasLimit)
+	assert.NoError(t, err, "Failed to create signed transaction")
+
+	// Send the transaction
+	_, err = service.SendRawTransaction(context.Background(), rawTx)
+	// Expect an error here because gas limit exceeds the chain limit
+	assert.Error(t, err, "Expected the SendRawTransaction function to return an error")
+
+	encodingErr, ok := err.(*rpc.EncodingError)
+	assert.True(t, ok, "Expected error of type *EncodingError")
+	assert.Equal(t, encodingErr.StatusCode, -32000, "Expected specific status code for gas limit error")
+	assert.Equal(t, encodingErr.Err.Error(), "gas limit is higher than allowed chain limit")
 }

--- a/src/rpc/service_eth_test.go
+++ b/src/rpc/service_eth_test.go
@@ -263,7 +263,7 @@ func TestNewTimeEvent_DeleteTxInfo(t *testing.T) {
 
 func TestSendRawTransaction_GasLimitExceedsChainLimit_Error(t *testing.T) {
 	service := initTest(t)
-	highGasLimit := service.Config.ChainGasLimit + 1
+	highGasLimit := service.Config.EncryptedGasLimit + 1
 	nonce := uint64(1)
 	chainID := big.NewInt(1)
 

--- a/src/testdata/test-data.go
+++ b/src/testdata/test-data.go
@@ -23,13 +23,16 @@ func GenerateKeyPair() (*ecdsa.PrivateKey, common.Address, error) {
 }
 
 func Tx(privateKey *ecdsa.PrivateKey, nonce uint64, chainID *big.Int) (string, *types.Transaction, error) {
-	return TxWithGas(privateKey, nonce, chainID, big.NewInt(2000000000))
+	return TxWithGas(privateKey, nonce, chainID, big.NewInt(2000000000), 21000)
 }
 
-func TxWithGas(privateKey *ecdsa.PrivateKey, nonce uint64, chainID *big.Int, gasPrice *big.Int) (string, *types.Transaction, error) {
+func TxWithGasPrice(privateKey *ecdsa.PrivateKey, nonce uint64, chainID *big.Int, gasPrice *big.Int) (string, *types.Transaction, error) {
+	return TxWithGas(privateKey, nonce, chainID, gasPrice, 21000)
+}
+
+func TxWithGas(privateKey *ecdsa.PrivateKey, nonce uint64, chainID *big.Int, gasPrice *big.Int, gasLimit uint64) (string, *types.Transaction, error) {
 	toAddress := common.HexToAddress("0xC0058BdcC93EaA1afd468f06A26394E2d80c8f01")
 	value := big.NewInt(120000000000) // in wei (0.12 eth)
-	gasLimit := uint64(21000)         // in units
 	maxPriorityFeePerGas := big.NewInt(2000000000)
 
 	tx := types.NewTx(&types.DynamicFeeTx{


### PR DESCRIPTION
Enforce that the gas limit on an incoming transactions does not go over the allowed gas limit used per block.