### PR TITLE
Update cache logic to send transactions until executed

### DIFF
--- a/src/cache/cache.go
+++ b/src/cache/cache.go
@@ -83,6 +83,7 @@ func (c *Cache) UpdateEntry(newTx *types.Transaction, currentTime int64) (bool, 
 	// first transaction
 	utils.Logger.Debug().Msgf("Adding transaction with hash [%s] and time [%v] to the cache at key [%s] \n", newTx.Hash(), currentTime, key)
 	c.Data[key] = TransactionInfo{Tx: newTx, CachedTime: currentTime}
-	utils.Logger.Debug().Msgf("Cache entry updated to: Tx = nil and CachedTime = [%d]", c.Data[key].CachedTime)
+	utils.Logger.Debug().Msgf("Cache entry updated to: Tx = [%s] and CachedTime = [%d]",
+		c.Data[key].Tx.Hash().Hex(), c.Data[key].CachedTime)
 	return true, nil // true -> send tx
 }

--- a/src/cache/cache.go
+++ b/src/cache/cache.go
@@ -45,39 +45,44 @@ func (c *Cache) UpdateEntry(newTx *types.Transaction, currentTime int64) (bool, 
 
 	utils.Logger.Debug().Msgf("Attempting to update cache with key [%s] and transaction hash [%s]", key, newTx.Hash().Hex())
 	if existing, found := c.Data[key]; found {
-		if existing.Tx != nil { // we sent a transaction in the last d seconds
-			// new tx with lower gas -> discard tx
-			utils.Logger.Debug().Msgf("Found cache entry with key [%s], transaction data Tx [%s] and CachedTime [%d]",
-				key, existing.Tx.Hash().Hex(), existing.CachedTime)
-			if newTx.GasPrice().Cmp(existing.Tx.GasPrice()) <= 0 {
-				utils.Logger.Debug().Msgf("A transaction already exists with a higher gas price. "+
-					"Delaying transaction sending to [%d].", currentTime)
-				txInfo := TransactionInfo{existing.Tx, existing.CachedTime}
+		if existing.Tx != nil {
+			if existing.CachedTime+c.DelayFactor > currentTime { // we sent a transaction within less than d seconds
+				// new tx with lower gas -> discard tx
+				utils.Logger.Debug().Msgf("Found cache entry with key [%s], transaction data Tx [%s] and CachedTime [%d]",
+					key, existing.Tx.Hash().Hex(), existing.CachedTime)
+				if newTx.GasPrice().Cmp(existing.Tx.GasPrice()) <= 0 {
+					utils.Logger.Debug().Msgf("A transaction already exists with a higher gas price. "+
+						"Delaying transaction sending to [%d].", currentTime)
+					txInfo := TransactionInfo{existing.Tx, existing.CachedTime}
+					c.Data[key] = txInfo
+					return false, nil // false -> tx won't be sent
+				}
+
+				// new tx with higher gas -> update tx
+				utils.Logger.Debug().Msgf("A transaction already exists with a lower gas price. "+
+					"Updating transaction and delaying transaction sending to [%d].", currentTime)
+				txInfo := TransactionInfo{newTx, existing.CachedTime}
 				c.Data[key] = txInfo
 				return false, nil // false -> tx won't be sent
 			}
 
-			// new tx with higher gas -> update tx
-			utils.Logger.Debug().Msgf("A transaction already exists with a lower gas price. "+
-				"Updating transaction and delaying transaction sending to [%d].", currentTime)
-			txInfo := TransactionInfo{newTx, existing.CachedTime}
-			c.Data[key] = txInfo
-			return false, nil // false -> tx won't be sent
-		}
+			// we sent a transaction within more than d seconds
+			utils.Logger.Debug().Msgf("Found cache entry with key [%s], transaction data Tx [%s] and CachedTime [%d]. Resending.",
+				key, existing.Tx.Hash().Hex(), existing.CachedTime)
 
-		// tx sent within the last d seconds
-		utils.Logger.Debug().Msgf("Found cache entry with nil value.")
-		utils.Logger.Debug().Msgf("Adding transaction with hash [%s] to the cache at key [%s]\n", newTx.Hash(), key)
-		txInfo := TransactionInfo{newTx, existing.CachedTime}
-		c.Data[key] = txInfo
-		utils.Logger.Debug().Msgf("Cache entry updated to: Tx = [%s] and CachedTime = [%d]",
-			c.Data[key].Tx.Hash().Hex(), c.Data[key].CachedTime)
-		return false, nil // false -> tx won't be sent
+			utils.Logger.Debug().Msgf("Adding transaction with hash [%s] to the cache at key [%s]\n", newTx.Hash(), key)
+			txInfo := TransactionInfo{newTx, currentTime}
+			c.Data[key] = txInfo
+			utils.Logger.Debug().Msgf("Cache entry updated to: Tx = [%s] and CachedTime = [%d]",
+				c.Data[key].Tx.Hash().Hex(), c.Data[key].CachedTime)
+			return true, nil // true -> tx will be sent
+
+		}
 	}
 
-	// no tx sent in the last d seconds
+	// first transaction
 	utils.Logger.Debug().Msgf("Adding transaction with hash [%s] and time [%v] to the cache at key [%s] \n", newTx.Hash(), currentTime, key)
-	c.Data[key] = TransactionInfo{Tx: nil, CachedTime: currentTime}
+	c.Data[key] = TransactionInfo{Tx: newTx, CachedTime: currentTime}
 	utils.Logger.Debug().Msgf("Cache entry updated to: Tx = nil and CachedTime = [%d]", c.Data[key].CachedTime)
 	return true, nil // true -> send tx
 }

--- a/src/cache/cache.go
+++ b/src/cache/cache.go
@@ -88,8 +88,6 @@ func (c *Cache) ProcessTxEntry(newTx *types.Transaction, currentTime int64) (boo
 
 	// first transaction
 	utils.Logger.Debug().Msgf("Adding transaction with hash [%s] and time [%v] to the cache at key [%s] \n", newTx.Hash(), currentTime, key)
-	c.Data[key] = TransactionInfo{Tx: newTx, CachedTime: currentTime}
-	utils.Logger.Debug().Msgf("Cache entry updated to: Tx = [%s] and CachedTime = [%d]",
-		c.Data[key].Tx.Hash().Hex(), c.Data[key].CachedTime)
+	c.UpdateEntry(key, newTx, currentTime)
 	return true, nil // true -> send tx
 }

--- a/src/cache/cache.go
+++ b/src/cache/cache.go
@@ -34,7 +34,14 @@ func (c *Cache) Key(tx *types.Transaction) (string, error) {
 	return fmt.Sprintf("%s-%d", fromAddress.Hex(), tx.Nonce()), nil
 }
 
-func (c *Cache) UpdateEntry(newTx *types.Transaction, currentTime int64) (bool, error) {
+func (c *Cache) UpdateEntry(key string, tx *types.Transaction, cachedTime int64) {
+	txInfo := TransactionInfo{Tx: tx, CachedTime: cachedTime}
+	c.Data[key] = txInfo
+	utils.Logger.Debug().Msgf("Cache entry at key [%s] updated to: Tx = [%s] and CachedTime = [%d]",
+		key, c.Data[key].Tx.Hash().Hex(), c.Data[key].CachedTime)
+}
+
+func (c *Cache) ProcessTxEntry(newTx *types.Transaction, currentTime int64) (bool, error) {
 	key, err := c.Key(newTx)
 	if err != nil {
 		return false, err
@@ -53,16 +60,13 @@ func (c *Cache) UpdateEntry(newTx *types.Transaction, currentTime int64) (bool, 
 				if newTx.GasPrice().Cmp(existing.Tx.GasPrice()) <= 0 {
 					utils.Logger.Debug().Msgf("A transaction already exists with a higher gas price. "+
 						"Delaying transaction sending to [%d].", currentTime)
-					txInfo := TransactionInfo{existing.Tx, existing.CachedTime}
-					c.Data[key] = txInfo
 					return false, nil // false -> tx won't be sent
 				}
 
 				// new tx with higher gas -> update tx
 				utils.Logger.Debug().Msgf("A transaction already exists with a lower gas price. "+
 					"Updating transaction and delaying transaction sending to [%d].", currentTime)
-				txInfo := TransactionInfo{newTx, existing.CachedTime}
-				c.Data[key] = txInfo
+				c.UpdateEntry(key, newTx, existing.CachedTime)
 				return false, nil // false -> tx won't be sent
 			}
 
@@ -72,17 +76,11 @@ func (c *Cache) UpdateEntry(newTx *types.Transaction, currentTime int64) (bool, 
 
 			if newTx.GasPrice().Cmp(existing.Tx.GasPrice()) <= 0 { // previous tx with higher gas price
 				utils.Logger.Debug().Msgf("Keeping transaction with hash [%s] in the cache at key [%s]\n", newTx.Hash(), key)
-				txInfo := TransactionInfo{existing.Tx, currentTime}
-				c.Data[key] = txInfo
-				utils.Logger.Debug().Msgf("Cache entry updated to: Tx = [%s] and CachedTime = [%d]",
-					c.Data[key].Tx.Hash().Hex(), c.Data[key].CachedTime)
+				c.UpdateEntry(key, existing.Tx, currentTime)
 				return true, nil // true -> tx will be sent
 			} else {
 				utils.Logger.Debug().Msgf("Adding transaction with hash [%s] to the cache at key [%s]\n", newTx.Hash(), key)
-				txInfo := TransactionInfo{newTx, currentTime}
-				c.Data[key] = txInfo
-				utils.Logger.Debug().Msgf("Cache entry updated to: Tx = [%s] and CachedTime = [%d]",
-					c.Data[key].Tx.Hash().Hex(), c.Data[key].CachedTime)
+				c.UpdateEntry(key, newTx, currentTime)
 				return true, nil // true -> tx will be sent
 			}
 		}

--- a/src/cache/cache_test.go
+++ b/src/cache/cache_test.go
@@ -50,7 +50,7 @@ func TestCache_UpdateEntry(t *testing.T) {
 	// Verify that the transaction in the cache matches the signed transaction
 	cachedTxInfo, exists := c.Data[key]
 	assert.True(t, exists, "Expected transaction to be in the cache")
-	assert.Nil(t, cachedTxInfo.Tx, "Expected cached transaction to be nil")
+	assert.Equal(t, cachedTxInfo.Tx, signedTx)
 }
 
 func TestCacheConcurrentUpdateEntry(t *testing.T) {

--- a/src/cache/cache_test.go
+++ b/src/cache/cache_test.go
@@ -28,6 +28,28 @@ func TestCache_Key(t *testing.T) {
 	assert.Equal(t, expectedKey, key, "Expected key does not match")
 }
 
+func TestCache_UpdateEntry(t *testing.T) {
+	privateKey, _, err := testdata.GenerateKeyPair()
+	assert.NoError(t, err, "Failed to generate key pair")
+
+	chainID := big.NewInt(1)
+	nonce := uint64(1)
+	_, signedTx, err := testdata.Tx(privateKey, nonce, chainID)
+	assert.NoError(t, err, "Failed to create signed transaction")
+
+	c := NewCache(10)
+
+	key := "testKey"
+	cachedTime := int64(1234)
+
+	c.UpdateEntry(key, signedTx, cachedTime)
+
+	entry, exists := c.Data[key]
+	assert.True(t, exists, "Key should exist in cache after UpdateEntry")
+	assert.Equal(t, signedTx, entry.Tx, "Transaction should match the updated one")
+	assert.Equal(t, cachedTime, entry.CachedTime, "CachedTime should match the updated one")
+}
+
 func TestCache_ProcessTxEntry(t *testing.T) {
 	c := NewCache(10)
 

--- a/src/cache/cache_test.go
+++ b/src/cache/cache_test.go
@@ -28,7 +28,7 @@ func TestCache_Key(t *testing.T) {
 	assert.Equal(t, expectedKey, key, "Expected key does not match")
 }
 
-func TestCache_UpdateEntry(t *testing.T) {
+func TestCache_ProcessTxEntry(t *testing.T) {
 	c := NewCache(10)
 
 	privateKey, fromAddress, err := testdata.GenerateKeyPair()
@@ -37,9 +37,9 @@ func TestCache_UpdateEntry(t *testing.T) {
 	_, signedTx, err := testdata.Tx(privateKey, 1, big.NewInt(1))
 	assert.NoError(t, err, "Failed to create signed transaction")
 
-	updated, err := c.UpdateEntry(signedTx, 100)
+	sendStatus, err := c.ProcessTxEntry(signedTx, 100)
 	assert.NoError(t, err, "Failed to update entry")
-	assert.True(t, updated, "Expected transaction to be added to cache")
+	assert.True(t, sendStatus, "Expected transaction send status to be true")
 
 	key, err := c.Key(signedTx)
 	assert.NoError(t, err, "Failed to get key from cache")
@@ -70,7 +70,7 @@ func TestCacheConcurrentUpdateEntry(t *testing.T) {
 		_, newTx, err := testdata.Tx(privateKey, nonce, chainID)
 		assert.Nil(t, err, "Error while creating transaction")
 		currentBlock := int64(1)
-		executed, err := c.UpdateEntry(newTx, currentBlock)
+		executed, err := c.ProcessTxEntry(newTx, currentBlock)
 		assert.Nil(t, err)
 		assert.True(t, executed)
 	}()
@@ -80,7 +80,7 @@ func TestCacheConcurrentUpdateEntry(t *testing.T) {
 		_, newTx, err := testdata.Tx(privateKey, nonce+1, chainID)
 		assert.Nil(t, err, "Error while creating transaction")
 		currentBlock := int64(2)
-		executed, err := c.UpdateEntry(newTx, currentBlock)
+		executed, err := c.ProcessTxEntry(newTx, currentBlock)
 		assert.Nil(t, err)
 		assert.True(t, executed)
 	}()

--- a/src/rpc/service_eth.go
+++ b/src/rpc/service_eth.go
@@ -180,13 +180,13 @@ func (service *EthService) SendRawTransaction(ctx context.Context, s string) (*c
 		return &txHash, nil
 	}
 
-	updated, err := service.Cache.UpdateEntry(tx, time.Now().Unix())
+	sendStatus, err := service.Cache.ProcessTxEntry(tx, time.Now().Unix())
 	if err != nil {
 		utils.Logger.Err(err).Msg("Failed to update the cache.")
 		return nil, &EncodingError{StatusCode: -32603, Err: err}
 	}
 
-	if !updated {
+	if !sendStatus {
 		utils.Logger.Info().Hex("Tx hash", txHash.Bytes()).Msg("Transaction delayed")
 		return &txHash, nil
 	}

--- a/src/rpc/service_eth.go
+++ b/src/rpc/service_eth.go
@@ -99,11 +99,10 @@ func (s *EthService) NewTimeEvent(ctx context.Context, newTime int64) {
 
 				utils.Logger.Info().Msg("Transaction sent internally: " + txHash.Hex())
 
-				txInfo := cache.TransactionInfo{info.Tx, newTime}
+				txInfo := cache.TransactionInfo{Tx: info.Tx, CachedTime: newTime}
 				s.Cache.Data[key] = txInfo
 				utils.Logger.Debug().Msgf("Cache entry updated to: Tx = [%s] and CachedTime = [%d]",
 					s.Cache.Data[key].Tx.Hash().Hex(), s.Cache.Data[key].CachedTime)
-
 			}
 		}
 	}

--- a/src/rpc/service_eth.go
+++ b/src/rpc/service_eth.go
@@ -98,11 +98,6 @@ func (s *EthService) NewTimeEvent(ctx context.Context, newTime int64) {
 				}
 
 				utils.Logger.Info().Msg("Transaction sent internally: " + txHash.Hex())
-
-				txInfo := cache.TransactionInfo{Tx: info.Tx, CachedTime: newTime}
-				s.Cache.Data[key] = txInfo
-				utils.Logger.Debug().Msgf("Cache entry updated to: Tx = [%s] and CachedTime = [%d]",
-					s.Cache.Data[key].Tx.Hash().Hex(), s.Cache.Data[key].CachedTime)
 			}
 		}
 	}

--- a/src/rpc/service_eth_test.go
+++ b/src/rpc/service_eth_test.go
@@ -214,7 +214,7 @@ func TestNewTimeEvent_UpdateTxInfo(t *testing.T) {
 
 	assert.True(t, exists, "Expected transaction information to be in the cache")
 	assert.Equal(t, currentTime, info.CachedTime, "Expected cached time to be updated")
-	assert.Equal(t, signedTx, info.Tx)
+	assertDynamicTxEquality(t, signedTx, info.Tx)
 }
 
 func TestNewTimeEvent_KeepTxInfoAndTime(t *testing.T) {
@@ -242,7 +242,7 @@ func TestNewTimeEvent_KeepTxInfoAndTime(t *testing.T) {
 
 func TestNewTimeEvent_KeepTxInfoUpdateTime(t *testing.T) {
 	service := initTest(t)
-	currentTime := int64(13)
+	currentTime := time.Now().Unix()
 	chainID := big.NewInt(1)
 
 	_, signedTx, _ := testdata.Tx(service.Processor.SigningKey, 1, chainID)

--- a/src/rpc/service_utils.go
+++ b/src/rpc/service_utils.go
@@ -1,0 +1,21 @@
+package rpc
+
+import (
+	"context"
+	"github.com/ethereum/go-ethereum/common"
+	"strconv"
+	"strings"
+)
+
+func (s *EthService) CheckNonceUsed(key string, ctx context.Context) bool {
+	keyAddress := strings.Split(key, "-")[0]
+	keyNonce := strings.Split(key, "-")[1]
+	nonce, err := strconv.ParseUint(keyNonce, 10, 64)
+	if err == nil {
+		accountNonce, err := s.Processor.Client.NonceAt(ctx, common.HexToAddress(keyAddress), nil)
+		if err == nil && accountNonce > nonce {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Temporary workaround to keep sending transactions until these are executed. 