### PR TITLE
Update cache logic to send transactions until executed

### DIFF
--- a/src/cache/cache.go
+++ b/src/cache/cache.go
@@ -64,20 +64,11 @@ func (c *Cache) UpdateEntry(newTx *types.Transaction, currentTime int64) (bool, 
 			c.Data[key] = txInfo
 			return false, nil // false -> tx won't be sent
 		}
-
-		// tx sent within the last d seconds
-		utils.Logger.Debug().Msgf("Found cache entry with nil value.")
-		utils.Logger.Debug().Msgf("Adding transaction with hash [%s] to the cache at key [%s]\n", newTx.Hash(), key)
-		txInfo := TransactionInfo{newTx, existing.CachedTime}
-		c.Data[key] = txInfo
-		utils.Logger.Debug().Msgf("Cache entry updated to: Tx = [%s] and CachedTime = [%d]",
-			c.Data[key].Tx.Hash().Hex(), c.Data[key].CachedTime)
-		return false, nil // false -> tx won't be sent
 	}
 
 	// no tx sent in the last d seconds
 	utils.Logger.Debug().Msgf("Adding transaction with hash [%s] and time [%v] to the cache at key [%s] \n", newTx.Hash(), currentTime, key)
-	c.Data[key] = TransactionInfo{Tx: nil, CachedTime: currentTime}
+	c.Data[key] = TransactionInfo{Tx: newTx, CachedTime: currentTime}
 	utils.Logger.Debug().Msgf("Cache entry updated to: Tx = nil and CachedTime = [%d]", c.Data[key].CachedTime)
 	return true, nil // true -> send tx
 }

--- a/src/cache/cache.go
+++ b/src/cache/cache.go
@@ -34,7 +34,14 @@ func (c *Cache) Key(tx *types.Transaction) (string, error) {
 	return fmt.Sprintf("%s-%d", fromAddress.Hex(), tx.Nonce()), nil
 }
 
-func (c *Cache) UpdateEntry(newTx *types.Transaction, currentTime int64) (bool, error) {
+func (c *Cache) UpdateEntry(key string, tx *types.Transaction, cachedTime int64) {
+	txInfo := TransactionInfo{Tx: tx, CachedTime: cachedTime}
+	c.Data[key] = txInfo
+	utils.Logger.Debug().Msgf("Cache entry at key [%s] updated to: Tx = [%s] and CachedTime = [%d]",
+		key, c.Data[key].Tx.Hash().Hex(), c.Data[key].CachedTime)
+}
+
+func (c *Cache) ProcessTxEntry(newTx *types.Transaction, currentTime int64) (bool, error) {
 	key, err := c.Key(newTx)
 	if err != nil {
 		return false, err
@@ -52,23 +59,19 @@ func (c *Cache) UpdateEntry(newTx *types.Transaction, currentTime int64) (bool, 
 			if newTx.GasPrice().Cmp(existing.Tx.GasPrice()) <= 0 {
 				utils.Logger.Debug().Msgf("A transaction already exists with a higher gas price. "+
 					"Delaying transaction sending to [%d].", currentTime)
-				txInfo := TransactionInfo{existing.Tx, existing.CachedTime}
-				c.Data[key] = txInfo
 				return false, nil // false -> tx won't be sent
 			}
 
 			// new tx with higher gas -> update tx
 			utils.Logger.Debug().Msgf("A transaction already exists with a lower gas price. "+
 				"Updating transaction and delaying transaction sending to [%d].", currentTime)
-			txInfo := TransactionInfo{newTx, existing.CachedTime}
-			c.Data[key] = txInfo
+			c.UpdateEntry(key, newTx, existing.CachedTime)
 			return false, nil // false -> tx won't be sent
 		}
 	}
 
 	// no tx sent in the last d seconds
 	utils.Logger.Debug().Msgf("Adding transaction with hash [%s] and time [%v] to the cache at key [%s] \n", newTx.Hash(), currentTime, key)
-	c.Data[key] = TransactionInfo{Tx: newTx, CachedTime: currentTime}
-	utils.Logger.Debug().Msgf("Cache entry updated to: Tx = nil and CachedTime = [%d]", c.Data[key].CachedTime)
+	c.UpdateEntry(key, newTx, currentTime)
 	return true, nil // true -> send tx
 }

--- a/src/cache/cache.go
+++ b/src/cache/cache.go
@@ -57,14 +57,14 @@ func (c *Cache) ProcessTxEntry(newTx *types.Transaction, currentTime int64) (boo
 			utils.Logger.Debug().Msgf("Found cache entry with key [%s], transaction data Tx [%s] and CachedTime [%d]",
 				key, existing.Tx.Hash().Hex(), existing.CachedTime)
 			if newTx.GasPrice().Cmp(existing.Tx.GasPrice()) <= 0 {
-				utils.Logger.Debug().Msgf("A transaction already exists with a higher gas price. "+
-					"Delaying transaction sending to [%d].", currentTime)
+				utils.Logger.Debug().Msgf("A transaction already exists with a higher gas price. " +
+					"Delaying transaction sending.")
 				return false, nil // false -> tx won't be sent
 			}
 
 			// new tx with higher gas -> update tx
-			utils.Logger.Debug().Msgf("A transaction already exists with a lower gas price. "+
-				"Updating transaction and delaying transaction sending to [%d].", currentTime)
+			utils.Logger.Debug().Msgf("A transaction already exists with a lower gas price. " +
+				"Updating transaction and delaying transaction sending.")
 			c.UpdateEntry(key, newTx, existing.CachedTime)
 			return false, nil // false -> tx won't be sent
 		}

--- a/src/cache/cache_test.go
+++ b/src/cache/cache_test.go
@@ -29,6 +29,28 @@ func TestCache_Key(t *testing.T) {
 }
 
 func TestCache_UpdateEntry(t *testing.T) {
+	privateKey, _, err := testdata.GenerateKeyPair()
+	assert.NoError(t, err, "Failed to generate key pair")
+
+	chainID := big.NewInt(1)
+	nonce := uint64(1)
+	_, signedTx, err := testdata.Tx(privateKey, nonce, chainID)
+	assert.NoError(t, err, "Failed to create signed transaction")
+
+	c := NewCache(10)
+
+	key := "testKey"
+	cachedTime := int64(1234)
+
+	c.UpdateEntry(key, signedTx, cachedTime)
+
+	entry, exists := c.Data[key]
+	assert.True(t, exists, "Key should exist in cache after UpdateEntry")
+	assert.Equal(t, signedTx, entry.Tx, "Transaction should match the updated one")
+	assert.Equal(t, cachedTime, entry.CachedTime, "CachedTime should match the updated one")
+}
+
+func TestCache_ProcessTxEntry(t *testing.T) {
 	c := NewCache(10)
 
 	privateKey, fromAddress, err := testdata.GenerateKeyPair()
@@ -37,9 +59,9 @@ func TestCache_UpdateEntry(t *testing.T) {
 	_, signedTx, err := testdata.Tx(privateKey, 1, big.NewInt(1))
 	assert.NoError(t, err, "Failed to create signed transaction")
 
-	updated, err := c.UpdateEntry(signedTx, 100)
+	sendStatus, err := c.ProcessTxEntry(signedTx, 100)
 	assert.NoError(t, err, "Failed to update entry")
-	assert.True(t, updated, "Expected transaction to be added to cache")
+	assert.True(t, sendStatus, "Expected transaction to be added to cache")
 
 	key, err := c.Key(signedTx)
 	assert.NoError(t, err, "Failed to get key from cache")
@@ -53,7 +75,7 @@ func TestCache_UpdateEntry(t *testing.T) {
 	assert.Equal(t, signedTx, cachedTxInfo.Tx, "Expected cached transaction to be nil")
 }
 
-func TestCacheConcurrentUpdateEntry(t *testing.T) {
+func TestCache_ConcurrentUpdateEntry(t *testing.T) {
 	c := NewCache(10)
 	var wg sync.WaitGroup
 	wg.Add(2)
@@ -70,7 +92,7 @@ func TestCacheConcurrentUpdateEntry(t *testing.T) {
 		_, newTx, err := testdata.Tx(privateKey, nonce, chainID)
 		assert.Nil(t, err, "Error while creating transaction")
 		currentBlock := int64(1)
-		executed, err := c.UpdateEntry(newTx, currentBlock)
+		executed, err := c.ProcessTxEntry(newTx, currentBlock)
 		assert.Nil(t, err)
 		assert.True(t, executed)
 	}()
@@ -80,7 +102,7 @@ func TestCacheConcurrentUpdateEntry(t *testing.T) {
 		_, newTx, err := testdata.Tx(privateKey, nonce+1, chainID)
 		assert.Nil(t, err, "Error while creating transaction")
 		currentBlock := int64(2)
-		executed, err := c.UpdateEntry(newTx, currentBlock)
+		executed, err := c.ProcessTxEntry(newTx, currentBlock)
 		assert.Nil(t, err)
 		assert.True(t, executed)
 	}()

--- a/src/cache/cache_test.go
+++ b/src/cache/cache_test.go
@@ -61,7 +61,7 @@ func TestCache_ProcessTxEntry(t *testing.T) {
 
 	sendStatus, err := c.ProcessTxEntry(signedTx, 100)
 	assert.NoError(t, err, "Failed to update entry")
-	assert.True(t, sendStatus, "Expected transaction to be added to cache")
+	assert.True(t, sendStatus, "Expected transaction send status to be true")
 
 	key, err := c.Key(signedTx)
 	assert.NoError(t, err, "Failed to get key from cache")
@@ -72,7 +72,7 @@ func TestCache_ProcessTxEntry(t *testing.T) {
 	// Verify that the transaction in the cache matches the signed transaction
 	cachedTxInfo, exists := c.Data[key]
 	assert.True(t, exists, "Expected transaction to be in the cache")
-	assert.Equal(t, signedTx, cachedTxInfo.Tx, "Expected cached transaction to be nil")
+	assert.Equal(t, signedTx, cachedTxInfo.Tx, "Cached transaction should match the updated one")
 }
 
 func TestCache_ConcurrentUpdateEntry(t *testing.T) {

--- a/src/cache/cache_test.go
+++ b/src/cache/cache_test.go
@@ -50,7 +50,7 @@ func TestCache_UpdateEntry(t *testing.T) {
 	// Verify that the transaction in the cache matches the signed transaction
 	cachedTxInfo, exists := c.Data[key]
 	assert.True(t, exists, "Expected transaction to be in the cache")
-	assert.Nil(t, cachedTxInfo.Tx, "Expected cached transaction to be nil")
+	assert.Equal(t, signedTx, cachedTxInfo.Tx, "Expected cached transaction to be nil")
 }
 
 func TestCacheConcurrentUpdateEntry(t *testing.T) {

--- a/src/rpc/service_eth.go
+++ b/src/rpc/service_eth.go
@@ -179,13 +179,13 @@ func (service *EthService) SendRawTransaction(ctx context.Context, s string) (*c
 		return &txHash, nil
 	}
 
-	updated, err := service.Cache.UpdateEntry(tx, time.Now().Unix())
+	sendStatus, err := service.Cache.ProcessTxEntry(tx, time.Now().Unix())
 	if err != nil {
 		utils.Logger.Err(err).Msg("Failed to update the cache.")
 		return nil, &EncodingError{StatusCode: -32603, Err: err}
 	}
 
-	if !updated {
+	if !sendStatus {
 		utils.Logger.Info().Hex("Tx hash", txHash.Bytes()).Msg("Transaction delayed")
 		return &txHash, nil
 	}

--- a/src/rpc/service_eth_test.go
+++ b/src/rpc/service_eth_test.go
@@ -98,7 +98,7 @@ func TestSendRawTransaction_Success(t *testing.T) {
 
 	assert.True(t, exists, "Expected transaction information to be in the cache")
 	assert.Equal(t, time.Now().Unix(), cachedTxInfo.CachedTime, "Expected sending block does not match")
-	assert.Nil(t, cachedTxInfo.Tx)
+	assertDynamicTxEquality(t, signedTx, cachedTxInfo.Tx)
 }
 
 func TestSendRawTransaction_TransactionInvalidNonce_NotSent(t *testing.T) {
@@ -214,7 +214,7 @@ func TestNewTimeEvent_UpdateTxInfo(t *testing.T) {
 
 	assert.True(t, exists, "Expected transaction information to be in the cache")
 	assert.Equal(t, currentTime, info.CachedTime, "Expected cached time to be updated")
-	assert.Nil(t, info.Tx)
+	assertDynamicTxEquality(t, signedTx, info.Tx)
 }
 
 func TestNewTimeEvent_KeepTxInfo(t *testing.T) {
@@ -278,5 +278,5 @@ func TestSendRawTransaction_GasLimitExceedsChainLimit_Error(t *testing.T) {
 	encodingErr, ok := err.(*rpc.EncodingError)
 	assert.True(t, ok, "Expected error of type *EncodingError")
 	assert.Equal(t, encodingErr.StatusCode, -32000, "Expected specific status code for gas limit error")
-	assert.Equal(t, encodingErr.Err.Error(), "gas limit is higher than allowed chain limit")
+	assert.Equal(t, encodingErr.Err.Error(), "gas limit exceeds encrypted gas limit (max gas limit allowed per shutterized block)")
 }


### PR DESCRIPTION
Temporary workaround to keep sending transactions until these are executed.