### PR TITLE
Add CORS headers to ERPC

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -19,6 +19,9 @@ services:
       caddy.@browser: "method GET"
       caddy.redir: "@browser https://blog.shutter.network/shutterized-gnosis-chain-is-now-live/"
       caddy.reverse_proxy: "{{ upstreams 8546 }}"
+      caddy.header.Access-Control-Allow-Origin: "*"
+      caddy.header.Access-Control-Allow-Methods: "GET, POST, OPTIONS"
+      caddy.header.Access-Control-Allow-Headers: "Content-Type, Authorization"
 
   caddy:
     image: lucaslorentz/caddy-docker-proxy:latest


### PR DESCRIPTION
Fix CORS configuration for ERPC:
- Added Access-Control-Allow-Origin: "*" header to allow all origins
- Included Access-Control-Allow-Methods: "GET, POST, OPTIONS" header to specify allowed HTTP methods
- Added Access-Control-Allow-Headers: "Content-Type, Authorization" header to specify allowed headers