### PR TITLE
feat: removed tx related labels from histograms

### DIFF
--- a/src/metrics/metrics.go
+++ b/src/metrics/metrics.go
@@ -4,7 +4,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-var TotalRequestDuration = prometheus.NewHistogramVec(
+var TotalRequestDuration = prometheus.NewHistogram(
 	prometheus.HistogramOpts{
 		Namespace: "encrypting_rpc_server",
 		Subsystem: "request",
@@ -12,10 +12,9 @@ var TotalRequestDuration = prometheus.NewHistogramVec(
 		Help:      "Histogram of the time it takes for all requests.",
 		Buckets:   prometheus.DefBuckets,
 	},
-	[]string{"encrypted_tx_hash", "tx_hash"},
 )
 
-var EncryptionDuration = prometheus.NewHistogramVec(
+var EncryptionDuration = prometheus.NewHistogram(
 	prometheus.HistogramOpts{
 		Namespace: "encrypting_rpc_server",
 		Subsystem: "request",
@@ -23,12 +22,11 @@ var EncryptionDuration = prometheus.NewHistogramVec(
 		Help:      "Histogram of the time it takes for encrypting a tx",
 		Buckets:   prometheus.DefBuckets,
 	},
-	[]string{"encrypted_tx_hash"},
 )
 
 var gasLimitBuckets = []float64{21000, 25000, 35000, 50000, 70000, 100000, 200000, 500000, 1000000, 10000000, 30000000}
 
-var RequestedGasLimit = prometheus.NewHistogramVec(
+var RequestedGasLimit = prometheus.NewHistogram(
 	prometheus.HistogramOpts{
 		Namespace: "encrypting_rpc_server",
 		Subsystem: "request",
@@ -36,7 +34,6 @@ var RequestedGasLimit = prometheus.NewHistogramVec(
 		Help:      "Histogram of the gas limit requested in tx",
 		Buckets:   gasLimitBuckets,
 	},
-	[]string{"encrypted_tx_hash"},
 )
 
 var UpstreamRequestDuration = prometheus.NewHistogramVec(
@@ -50,14 +47,13 @@ var UpstreamRequestDuration = prometheus.NewHistogramVec(
 	[]string{"method"},
 )
 
-var CancellationTxGauge = prometheus.NewGaugeVec(
+var CancellationTxGauge = prometheus.NewGauge(
 	prometheus.GaugeOpts{
 		Namespace: "encrypting_rpc_server",
 		Subsystem: "request",
 		Name:      "cancellation_txs_total",
 		Help:      "Counter of tx which were cancelled",
 	},
-	[]string{"tx_hash"},
 )
 
 var ErrorReturnedGauge = prometheus.NewGauge(

--- a/src/rpc/service_eth.go
+++ b/src/rpc/service_eth.go
@@ -193,7 +193,7 @@ func (service *EthService) SendRawTransaction(ctx context.Context, s string) (*c
 			return nil, returnError(-32602, err)
 		}
 
-		metrics.CancellationTxGauge.WithLabelValues(txHash.String()).Inc()
+		metrics.CancellationTxGauge.Inc()
 		utils.Logger.Info().Msg("Transaction forwarded with hash: " + txHash.Hex())
 
 		service.Processor.Db.InsertNewTx(db.TransactionDetails{
@@ -244,8 +244,8 @@ func (service *EthService) SendRawTransaction(ctx context.Context, s string) (*c
 	_ctx, cancelFunc := context.WithTimeout(context.Background(), time.Duration(service.Config.WaitMinedInterval)*10*time.Second)
 	go service.WaitTillMined(_ctx, cancelFunc, tx, service.Config.WaitMinedInterval)
 
-	metrics.RequestedGasLimit.WithLabelValues(submitTx.Hash().String()).Observe(float64(tx.Gas()))
-	metrics.TotalRequestDuration.WithLabelValues(submitTx.Hash().String(), txHash.String()).Observe(float64(time.Since(timeBefore).Seconds()))
+	metrics.RequestedGasLimit.Observe(float64(tx.Gas()))
+	metrics.TotalRequestDuration.Observe(float64(time.Since(timeBefore).Seconds()))
 
 	return &txHash, nil
 }
@@ -303,7 +303,7 @@ var DefaultProcessTransaction = func(tx *txtypes.Transaction, ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
-	metrics.EncryptionDuration.WithLabelValues(submitTx.Hash().String()).Observe(float64(encryptionDuration))
+	metrics.EncryptionDuration.Observe(float64(encryptionDuration))
 
 	return submitTx, nil
 }


### PR DESCRIPTION
This is required to not increase size of metrics page and make it scalable as all the info is now available in the associated postgres database.